### PR TITLE
Add configurable non-idempotent JSON-RPC methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Default behavior summary:
 | Cooldown threshold | `rcpx.DefaultCooldownFailAfterConsecutive` (`3`) consecutive failover-causing failures |
 | Cooldown duration | `rcpx.DefaultCooldownDuration` (`30s`) |
 | Non-idempotent failover | Disabled |
+| Additional non-idempotent methods | None |
 | Base transport | `http.DefaultTransport` |
 
 ### How failover works
@@ -384,7 +385,8 @@ When all upstreams are cooling down, requests fail with `*rcpx.AllUpstreamsFaile
 
 ```go
 type Config struct {
-	AllowNonIdempotent bool
+	AllowNonIdempotent             bool
+	AdditionalNonIdempotentMethods []string
 	// ...
 }
 ```
@@ -399,7 +401,9 @@ Current non-idempotent method list (built-in):
 * `eth_sendTransaction`
 * `eth_sendRawTransaction`
 
-The built-in non-idempotent method list is not currently configurable.
+`AdditionalNonIdempotentMethods` adds exact JSON-RPC method names to the built-in non-idempotent set. The built-in methods cannot be removed. Duplicate names are ignored, and empty names are invalid.
+
+`AllowNonIdempotent` applies to both built-in and configured methods.
 
 Batch requests are treated conservatively:
 

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -37,6 +38,10 @@ type Config struct {
 	// AdditionalRetryableStatusCodes are HTTP status codes retried in addition to
 	// the defaults: 429, 502, 503, and 504.
 	AdditionalRetryableStatusCodes []int
+
+	// AdditionalNonIdempotentMethods are JSON-RPC method names treated as
+	// non-idempotent in addition to the built-ins.
+	AdditionalNonIdempotentMethods []string
 }
 
 // CooldownConfig configures cooldown behavior.
@@ -73,7 +78,8 @@ type resolvedConfig struct {
 	bodyCap   int
 	policy    RetryPolicy
 
-	retryableStatuses map[int]struct{}
+	retryableStatuses    map[int]struct{}
+	nonIdempotentMethods map[string]struct{}
 }
 
 func resolveConfig(cfg Config) (resolvedConfig, error) {
@@ -131,6 +137,11 @@ func resolveConfig(cfg Config) (resolvedConfig, error) {
 		return resolvedConfig{}, err
 	}
 
+	nonIdempotentMethods, err := resolveNonIdempotentMethods(cfg.AdditionalNonIdempotentMethods)
+	if err != nil {
+		return resolvedConfig{}, err
+	}
+
 	return resolvedConfig{
 		upstreams: upstreams,
 		base:      base,
@@ -139,7 +150,8 @@ func resolveConfig(cfg Config) (resolvedConfig, error) {
 		bodyCap:   bodyCap,
 		policy:    policy,
 
-		retryableStatuses: statuses,
+		retryableStatuses:    statuses,
+		nonIdempotentMethods: nonIdempotentMethods,
 	}, nil
 }
 
@@ -200,4 +212,21 @@ func resolveRetryableStatusCodes(additional []int) (map[int]struct{}, error) {
 
 func validHTTPStatusCode(code int) bool {
 	return code >= 100 && code <= 999
+}
+
+func resolveNonIdempotentMethods(additional []string) (map[string]struct{}, error) {
+	methods := map[string]struct{}{
+		"eth_sendTransaction":    {},
+		"eth_sendRawTransaction": {},
+	}
+
+	for i, method := range additional {
+		if strings.TrimSpace(method) == "" {
+			return nil, fmt.Errorf("rcpx: invalid AdditionalNonIdempotentMethods[%d]: empty method name", i)
+		}
+
+		methods[method] = struct{}{}
+	}
+
+	return methods, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -128,6 +128,38 @@ func TestNewRoundTripper_validation(t *testing.T) {
 			t.Fatalf("expected duplicate status codes to be accepted, got %v", err)
 		}
 	})
+
+	t.Run("invalid additional non idempotent methods", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			method string
+		}{
+			{name: "empty", method: ""},
+			{name: "whitespace only", method: " \t\n"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := NewRoundTripper(Config{
+					Upstreams:                      []string{upstream},
+					AdditionalNonIdempotentMethods: []string{tt.method},
+				})
+				if err == nil {
+					t.Fatalf("expected error for method %q, got nil", tt.method)
+				}
+			})
+		}
+	})
+
+	t.Run("duplicate additional non idempotent methods are accepted", func(t *testing.T) {
+		_, err := NewRoundTripper(Config{
+			Upstreams:                      []string{upstream},
+			AdditionalNonIdempotentMethods: []string{"custom_send", "custom_send"},
+		})
+		if err != nil {
+			t.Fatalf("expected duplicate methods to be accepted, got %v", err)
+		}
+	})
 }
 
 func TestNewRoundTripper_defaults(t *testing.T) {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -5,18 +5,13 @@ import (
 	"encoding/json"
 )
 
-var nonIdempotentMethods = map[string]struct{}{
-	"eth_sendTransaction":    {},
-	"eth_sendRawTransaction": {},
-}
-
 // parseJSONRPCMethod best-effort extracts method info from a JSON-RPC request
 // body (single object or batch array).
 //
 // Safety rail: if any part of a batch is unknown/unparseable for method
 // extraction, the batch is treated as non-idempotent. If ok is false, callers
 // must treat the request as non-idempotent.
-func parseJSONRPCMethod(body []byte) (method string, batch bool, nonIdempotent bool, ok bool) {
+func parseJSONRPCMethod(body []byte, nonIdempotentMethods map[string]struct{}) (method string, batch bool, nonIdempotent bool, ok bool) {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
 		return "", false, false, false

--- a/transport.go
+++ b/transport.go
@@ -105,7 +105,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Best-effort method parsing; parse failure => treat as non-idempotent.
-	method, batch, nonIdempotent, ok := parseJSONRPCMethod(body)
+	method, batch, nonIdempotent, ok := parseJSONRPCMethod(body, t.cfg.nonIdempotentMethods)
 	if !ok {
 		nonIdempotent = true
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -578,6 +578,113 @@ func TestRoundTrip_NonIdempotentAllowed_FailoverSucceeds(t *testing.T) {
 	assertCalls(t, base, u1, u2)
 }
 
+func TestRoundTrip_AdditionalNonIdempotentMethod_BlockedByDefault(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: nil, err: io.EOF}},
+			u2: {{resp: httpResp(200, "ok")}}, // should not be called when blocked
+		},
+	}
+
+	rt := mustNewTransport(t, Config{
+		Upstreams:                      []string{u1, u2},
+		Base:                           base,
+		AdditionalNonIdempotentMethods: []string{"custom_send"},
+	})
+
+	req := newRPCRequest(t, u1, "custom_send")
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+
+	var be *NonIdempotentBlockedError
+	if !errors.As(err, &be) {
+		t.Fatalf("expected NonIdempotentBlockedError, got %v", err)
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected underlying cause io.EOF, got %v", err)
+	}
+	if be.Outcome.Method != "custom_send" {
+		t.Fatalf("expected blocked method custom_send, got %q", be.Outcome.Method)
+	}
+
+	assertCalls(t, base, u1)
+}
+
+func TestRoundTrip_AdditionalNonIdempotentMethod_AllowNonIdempotentFailsOver(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: nil, err: io.EOF}},
+			u2: {{resp: httpResp(200, "ok")}},
+		},
+	}
+
+	rt := mustNewTransport(t, Config{
+		Upstreams:                      []string{u1, u2},
+		Base:                           base,
+		AllowNonIdempotent:             true,
+		AdditionalNonIdempotentMethods: []string{"custom_send"},
+	})
+
+	req := newRPCRequest(t, u1, "custom_send")
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assertStatus(t, resp, 200)
+	assertCalls(t, base, u1, u2)
+}
+
+func TestRoundTrip_BatchWithAdditionalNonIdempotentMethod_BlockedByDefault(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: nil, err: io.EOF}},
+			u2: {{resp: httpResp(200, "ok")}}, // should not be called when blocked
+		},
+	}
+
+	rt := mustNewTransport(t, Config{
+		Upstreams:                      []string{u1, u2},
+		Base:                           base,
+		AdditionalNonIdempotentMethods: []string{"custom_send"},
+	})
+
+	req := newJSONRequest(t, u1, `[
+		{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]},
+		{"jsonrpc":"2.0","id":2,"method":"custom_send","params":[]}
+	]`)
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+
+	var be *NonIdempotentBlockedError
+	if !errors.As(err, &be) {
+		t.Fatalf("expected NonIdempotentBlockedError, got %v", err)
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected underlying cause io.EOF, got %v", err)
+	}
+	if !be.Outcome.Batch {
+		t.Fatalf("expected batch outcome")
+	}
+
+	assertCalls(t, base, u1)
+}
+
 func TestRoundTrip_ContextDoneBeforeCall_BaseNotCalled(t *testing.T) {
 	u1 := "https://u1.test/rpc"
 


### PR DESCRIPTION
Adds Config.AdditionalNonIdempotentMethods for marking extra JSON-RPC method names as non-idempotent, while keeping the built-in defaults unchanged.

The built-in methods remain eth_sendTransaction and eth_sendRawTransaction. Configured methods are additive and matched exactly. AllowNonIdempotent applies to both built-in and configured methods.

Includes tests for single requests, batch requests, validation, and README updates.

Closes #3