### PR TITLE
Add attempt observation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,42 @@ The retry policy is not called:
 
 `RetryPolicy` receives `AttemptOutcome`; it cannot inspect response bodies or response headers. It can decide whether rcpx should continue after an already-classified non-success attempt, but it is not a general response validation hook.
 
+### Attempt observation
+
+```go
+type Config struct {
+	OnAttempt func(rcpx.AttemptInfo)
+	// ...
+}
+
+type AttemptInfo struct {
+	Attempt    int
+	Upstream   string
+	Method     string
+	Batch      bool
+	StatusCode int
+	Err        error
+	Final      bool
+}
+```
+
+`OnAttempt`, if set, is called once for each attempted upstream. It can be used for logging or metrics, including recording which upstream handled a successful request.
+
+`AttemptInfo` includes:
+
+* `Attempt` (1-based attempt number for the current request)
+* `Upstream` (the configured upstream URL attempted)
+* JSON-RPC info (best-effort): `Method`, `Batch`
+* `StatusCode` (0 if no HTTP response was obtained)
+* `Err` (the attempt failure cause, if any)
+* `Final` (whether rcpx will make no further upstream attempts for this request after this attempt)
+
+`Final` is true for the attempt that returns a successful response, and also for terminal failures such as the last eligible upstream failing, retry policy stopping failover, or the non-idempotent safety rail blocking failover.
+
+The callback is called synchronously. If it blocks, the request blocks.
+
+`Upstream` is the configured upstream string and is not redacted. It may contain credentials if your upstream URLs contain credentials.
+
 ### Request body buffering cap
 
 ```go

--- a/config.go
+++ b/config.go
@@ -42,6 +42,36 @@ type Config struct {
 	// AdditionalNonIdempotentMethods are JSON-RPC method names treated as
 	// non-idempotent in addition to the built-ins.
 	AdditionalNonIdempotentMethods []string
+
+	// OnAttempt, if non-nil, is called after each upstream attempt with basic
+	// attempt outcome information. The callback is called synchronously.
+	OnAttempt func(AttemptInfo)
+}
+
+// AttemptInfo describes one upstream attempt observed by Config.OnAttempt.
+type AttemptInfo struct {
+	// Attempt is the 1-based attempt number for the current request.
+	Attempt int
+
+	// Upstream is the configured upstream URL attempted.
+	//
+	// It is not redacted and may contain credentials if the configured URL
+	// contains them.
+	Upstream string
+
+	// Method and Batch describe the JSON-RPC request body, best-effort.
+	Method string
+	Batch  bool
+
+	// StatusCode is 0 when no HTTP response was obtained.
+	StatusCode int
+
+	// Err is the attempt failure cause, if any.
+	Err error
+
+	// Final reports whether rcpx will make no further upstream attempts for
+	// this request after this attempt.
+	Final bool
 }
 
 // CooldownConfig configures cooldown behavior.
@@ -76,7 +106,9 @@ type resolvedConfig struct {
 	cooldown  effectiveCooldown
 	allowNI   bool
 	bodyCap   int
+
 	policy    RetryPolicy
+	onAttempt func(AttemptInfo)
 
 	retryableStatuses    map[int]struct{}
 	nonIdempotentMethods map[string]struct{}
@@ -149,6 +181,7 @@ func resolveConfig(cfg Config) (resolvedConfig, error) {
 		allowNI:   cfg.AllowNonIdempotent,
 		bodyCap:   bodyCap,
 		policy:    policy,
+		onAttempt: cfg.OnAttempt,
 
 		retryableStatuses:    statuses,
 		nonIdempotentMethods: nonIdempotentMethods,

--- a/transport.go
+++ b/transport.go
@@ -89,6 +89,22 @@ func (t *transport) eligibleUpstreams(now time.Time) (eligible []int, skippedCoo
 	return eligible, skippedCooldown
 }
 
+func (t *transport) notifyAttempt(attempt int, upstream, method string, batch bool, statusCode int, err error, final bool) {
+	if t.cfg.onAttempt == nil {
+		return
+	}
+
+	t.cfg.onAttempt(AttemptInfo{
+		Attempt:    attempt,
+		Upstream:   upstream,
+		Method:     method,
+		Batch:      batch,
+		StatusCode: statusCode,
+		Err:        err,
+		Final:      final,
+	})
+}
+
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req == nil {
 		return nil, errors.New("rcpx: nil request")
@@ -134,7 +150,13 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// Cancellation rail: return immediately; policy is not called.
 		if isCanceledOrDeadline(ctx, rerr) || ctx.Err() != nil {
+			finalErr := rerr
+			if ctx.Err() != nil {
+				finalErr = ctx.Err()
+			}
 			closeResponseBody(resp)
+			t.notifyAttempt(attemptNo, up.raw, method, batch, 0, finalErr, true)
+
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
@@ -150,6 +172,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Non-retryable HTTP statuses are treated as "success" from rcpx's
 		// perspective and returned unchanged.
 		if t.cfg.isAttemptSuccess(status, rerr) {
+			t.notifyAttempt(attemptNo, up.raw, method, batch, status, nil, true)
 			if t.cooldown != nil {
 				t.cooldown.recordSuccess(idx)
 			}
@@ -174,6 +197,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Idempotency rail: non-idempotent requests never fail over unless allowed.
 		if nonIdempotent && !t.cfg.allowNI && continueToNext {
 			closeResponseBody(resp)
+			t.notifyAttempt(attemptNo, up.raw, method, batch, status, cause, true)
 			return nil, &NonIdempotentBlockedError{
 				Outcome: out,
 				Cause:   cause,
@@ -182,6 +206,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		if continueToNext {
 			closeResponseBody(resp)
+			t.notifyAttempt(attemptNo, up.raw, method, batch, status, cause, false)
 
 			if t.cooldown != nil {
 				t.cooldown.recordFailoverFailure(now, idx)
@@ -198,6 +223,8 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		closeResponseBody(resp)
+
+		t.notifyAttempt(attemptNo, up.raw, method, batch, status, cause, true)
 
 		failures = append(failures, AttemptFailure{
 			Upstream:   up.raw,

--- a/transport_test.go
+++ b/transport_test.go
@@ -498,6 +498,256 @@ func TestRoundTrip_PolicyCanStopFailoverOnRetryableStatus(t *testing.T) {
 	assertCalls(t, base, u1)
 }
 
+func TestRoundTrip_OnAttempt_SuccessFirstAttempt(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: httpResp(200, "ok"), err: nil}},
+		},
+	}
+
+	var attempts []AttemptInfo
+	rt := mustNewTransport(t, Config{
+		Upstreams: []string{u1},
+		Base:      base,
+		OnAttempt: func(info AttemptInfo) {
+			attempts = append(attempts, info)
+		},
+	})
+
+	req := newRPCRequest(t, u1, "eth_blockNumber")
+	resp := mustRoundTrip(t, rt, req)
+	assertStatus(t, resp, 200)
+
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt observation, got %d: %#v", len(attempts), attempts)
+	}
+
+	got := attempts[0]
+	if got.Attempt != 1 {
+		t.Fatalf("expected Attempt=1, got %d", got.Attempt)
+	}
+	if got.Upstream != u1 {
+		t.Fatalf("expected Upstream=%q, got %q", u1, got.Upstream)
+	}
+	if got.Method != "eth_blockNumber" {
+		t.Fatalf("expected Method=eth_blockNumber, got %q", got.Method)
+	}
+	if got.Batch {
+		t.Fatalf("expected Batch=false")
+	}
+	if got.StatusCode != 200 {
+		t.Fatalf("expected StatusCode=200, got %d", got.StatusCode)
+	}
+	if got.Err != nil {
+		t.Fatalf("expected Err=nil, got %v", got.Err)
+	}
+	if !got.Final {
+		t.Fatalf("expected Final=true")
+	}
+
+	assertCalls(t, base, u1)
+}
+
+func TestRoundTrip_OnAttempt_Failover(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	respBody := newTrackingBody("service unavailable")
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: &http.Response{StatusCode: 503, Body: respBody}, err: nil}},
+			u2: {{resp: httpResp(200, "ok"), err: nil}},
+		},
+	}
+
+	var attempts []AttemptInfo
+	rt := mustNewTransport(t, Config{
+		Upstreams: []string{u1, u2},
+		Base:      base,
+		OnAttempt: func(info AttemptInfo) {
+			attempts = append(attempts, info)
+		},
+	})
+
+	req := newRPCRequest(t, u1, "eth_blockNumber")
+	resp := mustRoundTrip(t, rt, req)
+	assertStatus(t, resp, 200)
+
+	if len(attempts) != 2 {
+		t.Fatalf("expected 2 attempt observations, got %d: %#v", len(attempts), attempts)
+	}
+
+	first := attempts[0]
+	if first.Attempt != 1 {
+		t.Fatalf("expected first Attempt=1, got %d", first.Attempt)
+	}
+	if first.Upstream != u1 {
+		t.Fatalf("expected first Upstream=%q, got %q", u1, first.Upstream)
+	}
+	if first.Method != "eth_blockNumber" {
+		t.Fatalf("expected first Method=eth_blockNumber, got %q", first.Method)
+	}
+	if first.Batch {
+		t.Fatalf("expected first Batch=false")
+	}
+	if first.StatusCode != 503 {
+		t.Fatalf("expected first StatusCode=503, got %d", first.StatusCode)
+	}
+	if first.Err == nil {
+		t.Fatalf("expected first Err to be non nil")
+	}
+	if first.Final {
+		t.Fatalf("expected first Final=false")
+	}
+
+	second := attempts[1]
+	if second.Attempt != 2 {
+		t.Fatalf("expected second Attempt=2, got %d", second.Attempt)
+	}
+	if second.Upstream != u2 {
+		t.Fatalf("expected second Upstream=%q, got %q", u2, second.Upstream)
+	}
+	if second.Method != "eth_blockNumber" {
+		t.Fatalf("expected second Method=eth_blockNumber, got %q", second.Method)
+	}
+	if second.Batch {
+		t.Fatalf("expected second Batch=false")
+	}
+	if second.StatusCode != 200 {
+		t.Fatalf("expected second StatusCode=200, got %d", second.StatusCode)
+	}
+	if second.Err != nil {
+		t.Fatalf("expected second Err=nil, got %v", second.Err)
+	}
+	if !second.Final {
+		t.Fatalf("expected second Final=true")
+	}
+
+	if !respBody.Closed() {
+		t.Fatalf("expected 503 response body to be closed before failover")
+	}
+	assertCalls(t, base, u1, u2)
+}
+
+func TestRoundTrip_OnAttempt_PolicyStopsFailover(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	respBody := newTrackingBody("service unavailable")
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: &http.Response{StatusCode: 503, Body: respBody}, err: nil}},
+			u2: {{resp: httpResp(200, "ok"), err: nil}},
+		},
+	}
+
+	var attempts []AttemptInfo
+	pol, policy := newPolicyRecorder(false)
+	rt := mustNewTransport(t, Config{
+		Upstreams:   []string{u1, u2},
+		Base:        base,
+		RetryPolicy: policy,
+		OnAttempt: func(info AttemptInfo) {
+			attempts = append(attempts, info)
+		},
+	})
+
+	req := newRPCRequest(t, u1, "eth_blockNumber")
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+
+	ae := mustAsAllUpstreamsFailed(t, err)
+	if ae.Attempted != 1 {
+		t.Fatalf("expected Attempted=1, got %d", ae.Attempted)
+	}
+
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt observation, got %d: %#v", len(attempts), attempts)
+	}
+
+	got := attempts[0]
+	if got.Attempt != 1 {
+		t.Fatalf("expected Attempt=1, got %d", got.Attempt)
+	}
+	if got.Upstream != u1 {
+		t.Fatalf("expected Upstream=%q, got %q", u1, got.Upstream)
+	}
+	if got.StatusCode != 503 {
+		t.Fatalf("expected StatusCode=503, got %d", got.StatusCode)
+	}
+	if got.Err == nil {
+		t.Fatalf("expected Err to be non nil")
+	}
+	if !got.Final {
+		t.Fatalf("expected Final=true")
+	}
+
+	assertPolicyCalls(t, pol, 1)
+	if !respBody.Closed() {
+		t.Fatalf("expected 503 response body closed when not failing over")
+	}
+	assertCalls(t, base, u1)
+}
+
+func TestRoundTrip_OnAttempt_NonIdempotentBlocked(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {{resp: nil, err: io.EOF}},
+			u2: {{resp: httpResp(200, "ok"), err: nil}},
+		},
+	}
+
+	var attempts []AttemptInfo
+	rt := mustNewTransport(t, Config{
+		Upstreams: []string{u1, u2},
+		Base:      base,
+		OnAttempt: func(info AttemptInfo) {
+			attempts = append(attempts, info)
+		},
+	})
+
+	req := newRPCRequest(t, u1, "eth_sendRawTransaction")
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+
+	assertNonIdempotentBlocked(t, err, io.EOF)
+
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt observation, got %d: %#v", len(attempts), attempts)
+	}
+
+	got := attempts[0]
+	if got.Attempt != 1 {
+		t.Fatalf("expected Attempt=1, got %d", got.Attempt)
+	}
+	if got.Upstream != u1 {
+		t.Fatalf("expected Upstream=%q, got %q", u1, got.Upstream)
+	}
+	if got.Method != "eth_sendRawTransaction" {
+		t.Fatalf("expected Method=eth_sendRawTransaction, got %q", got.Method)
+	}
+	if got.StatusCode != 0 {
+		t.Fatalf("expected StatusCode=0, got %d", got.StatusCode)
+	}
+	if !errors.Is(got.Err, io.EOF) {
+		t.Fatalf("expected Err to be io.EOF, got %v", got.Err)
+	}
+	if !got.Final {
+		t.Fatalf("expected Final=true")
+	}
+
+	assertCalls(t, base, u1)
+}
+
 func TestRoundTrip_NonIdempotentBlockedByDefault(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Adds `Config.OnAttempt` for observing which upstreams rcpx attempts, including the upstream that handles a successful request.

The callback receives `AttemptInfo` with the attempt number, upstream URL, best-effort JSON-RPC method info, status code, error, and whether the attempt was final. It is called once per attempted upstream and does not affect retry, failover, cooldown, or non-idempotent safety behavior.

Includes tests for success, failover, retry policy stop, and non-idempotent blocking. Updates the README with the new hook behavior and raw upstream URL caveat.

Closes #6