### PR TITLE
Add deadline-exceeded cooldown option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Default behavior summary:
 | Cooldown | Enabled |
 | Cooldown threshold | `rcpx.DefaultCooldownFailAfterConsecutive` (`3`) consecutive failover-causing failures |
 | Cooldown duration | `rcpx.DefaultCooldownDuration` (`30s`) |
+| Deadline-exceeded cooldown failures | Disabled |
 | Non-idempotent failover | Disabled |
 | Additional non-idempotent methods | None |
 | Base transport | `http.DefaultTransport` |
@@ -389,9 +390,10 @@ type Config struct {
 }
 
 type CooldownConfig struct {
-	Disabled             bool
-	FailAfterConsecutive int
-	Duration             time.Duration
+	Disabled              bool
+	FailAfterConsecutive  int
+	Duration              time.Duration
+	CountDeadlineExceeded bool
 }
 ```
 
@@ -403,6 +405,7 @@ Behavior:
 * Only failures that caused rcpx to continue to another upstream count toward the consecutive failure threshold.
 * Once an upstream hits the threshold, it is skipped for the configured duration.
 * A successful attempt on an upstream resets its cooldown counters.
+* If `CountDeadlineExceeded` is enabled, an attempted `context.DeadlineExceeded` also counts toward the threshold. The current request still returns immediately and does not fail over.
 
 Configuration:
 
@@ -411,6 +414,7 @@ Configuration:
 
   * `FailAfterConsecutive == 0` uses `rcpx.DefaultCooldownFailAfterConsecutive` (3).
   * `Duration == 0` uses `rcpx.DefaultCooldownDuration` (30s).
+  * `CountDeadlineExceeded` is disabled by default.
 * Negative values for `FailAfterConsecutive` or `Duration` are invalid and cause `NewRoundTripper` to return an error.
 
 Cooldown is time-based. When the cooldown duration expires, the upstream becomes eligible again; rcpx does not perform a health check before reusing it. Cooldown does not prove that an upstream is fresh, synced, at a particular block height, or returning correct JSON-RPC data.
@@ -566,7 +570,7 @@ if errors.As(err, &be) {
 
 ### Cancellation and deadlines
 
-If the request context is canceled or its deadline is exceeded, rcpx returns immediately. You can check for these conditions with `errors.Is`:
+If the request context is canceled or its deadline is exceeded, rcpx returns immediately and does not fail over within that request. With `CooldownConfig.CountDeadlineExceeded` enabled, an attempted `context.DeadlineExceeded` can count toward cooldown for future requests; `context.Canceled` does not count. You can check for these conditions with `errors.Is`:
 
 ```go
 if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/config.go
+++ b/config.go
@@ -85,6 +85,10 @@ type CooldownConfig struct {
 
 	// 0 => DefaultCooldownDuration (unless Disabled=true)
 	Duration time.Duration
+
+	// CountDeadlineExceeded records attempted context.DeadlineExceeded outcomes
+	// as cooldown failures. It does not affect context.Canceled.
+	CountDeadlineExceeded bool
 }
 
 // resolvedUpstream is the normalized form of a user-provided upstream string.
@@ -94,9 +98,10 @@ type resolvedUpstream struct {
 }
 
 type effectiveCooldown struct {
-	enabled   bool
-	failAfter int
-	duration  time.Duration
+	enabled               bool
+	failAfter             int
+	duration              time.Duration
+	countDeadlineExceeded bool
 }
 
 // resolvedConfig is the internal, fully-normalized configuration used at runtime.
@@ -219,9 +224,10 @@ func resolveCooldown(cc *CooldownConfig) (effectiveCooldown, error) {
 	}
 
 	return effectiveCooldown{
-		enabled:   true,
-		failAfter: failAfter,
-		duration:  dur,
+		enabled:               true,
+		failAfter:             failAfter,
+		duration:              dur,
+		countDeadlineExceeded: cc.CountDeadlineExceeded,
 	}, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -213,4 +213,25 @@ func TestNewRoundTripper_defaults(t *testing.T) {
 			t.Fatalf("expected bodyCap=%d, got %d", DefaultBodyBufferBytes, tr.cfg.bodyCap)
 		}
 	})
+
+	t.Run("cooldown deadline exceeded counting defaults disabled", func(t *testing.T) {
+		tr := newTransportTest(t, Config{Upstreams: []string{upstream}})
+
+		if tr.cfg.cooldown.countDeadlineExceeded {
+			t.Fatal("expected CountDeadlineExceeded to default false")
+		}
+	})
+
+	t.Run("cooldown deadline exceeded counting can be enabled", func(t *testing.T) {
+		tr := newTransportTest(t, Config{
+			Upstreams: []string{upstream},
+			Cooldown: &CooldownConfig{
+				CountDeadlineExceeded: true,
+			},
+		})
+
+		if !tr.cfg.cooldown.countDeadlineExceeded {
+			t.Fatal("expected CountDeadlineExceeded to resolve true")
+		}
+	})
 }

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package rcpx
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -153,6 +154,12 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			finalErr := rerr
 			if ctx.Err() != nil {
 				finalErr = ctx.Err()
+			}
+			if t.cooldown != nil &&
+				t.cfg.cooldown.countDeadlineExceeded &&
+				errors.Is(finalErr, context.DeadlineExceeded) &&
+				!errors.Is(finalErr, context.Canceled) {
+				t.cooldown.recordFailoverFailure(now, idx)
 			}
 			closeResponseBody(resp)
 			t.notifyAttempt(attemptNo, up.raw, method, batch, 0, finalErr, true)

--- a/transport_test.go
+++ b/transport_test.go
@@ -1075,6 +1075,138 @@ func TestRoundTrip_CanceledByBaseWithResponse_ClosesBodyAndReturnsImmediately(t 
 	assertCalls(t, base, u1)
 }
 
+func TestRoundTrip_DeadlineExceededCountsForCooldownWhenEnabled(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {
+				{resp: nil, err: context.DeadlineExceeded},
+			},
+			u2: {
+				{resp: httpResp(200, "ok"), err: nil},
+			},
+		},
+	}
+
+	tr := mustNewTransport(t, Config{
+		Upstreams: []string{u1, u2},
+		Base:      base,
+		Cooldown: &CooldownConfig{
+			FailAfterConsecutive:  1,
+			Duration:              time.Hour,
+			CountDeadlineExceeded: true,
+		},
+	})
+	fixedNow := time.Unix(400, 0)
+	tr.now = func() time.Time { return fixedNow }
+
+	req1 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp, err := tr.RoundTrip(req1)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+
+	// The expired request returns immediately. The next request skips u1 because
+	// the deadline counted toward cooldown.
+	req2 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp = mustRoundTrip(t, tr, req2)
+	assertStatus(t, resp, 200)
+
+	assertCalls(t, base, u1, u2)
+}
+
+func TestRoundTrip_DeadlineExceededDoesNotCountForCooldownByDefault(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {
+				{resp: nil, err: context.DeadlineExceeded},
+				{resp: httpResp(200, "ok"), err: nil},
+			},
+			u2: {
+				{resp: httpResp(200, "unexpected"), err: nil},
+			},
+		},
+	}
+
+	tr := mustNewTransport(t, Config{
+		Upstreams: []string{u1, u2},
+		Base:      base,
+		Cooldown: &CooldownConfig{
+			FailAfterConsecutive: 1,
+			Duration:             time.Hour,
+		},
+	})
+	fixedNow := time.Unix(500, 0)
+	tr.now = func() time.Time { return fixedNow }
+
+	req1 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp, err := tr.RoundTrip(req1)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+
+	req2 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp = mustRoundTrip(t, tr, req2)
+	assertStatus(t, resp, 200)
+
+	assertCalls(t, base, u1, u1)
+}
+
+func TestRoundTrip_CanceledDoesNotCountForCooldownWhenDeadlineCountingEnabled(t *testing.T) {
+	u1 := "https://u1.test/rpc"
+	u2 := "https://u2.test/rpc"
+
+	base := &scriptRT{
+		results: map[string][]rtResult{
+			u1: {
+				{resp: nil, err: context.Canceled},
+				{resp: httpResp(200, "ok"), err: nil},
+			},
+			u2: {
+				{resp: httpResp(200, "unexpected"), err: nil},
+			},
+		},
+	}
+
+	tr := mustNewTransport(t, Config{
+		Upstreams: []string{u1, u2},
+		Base:      base,
+		Cooldown: &CooldownConfig{
+			FailAfterConsecutive:  1,
+			Duration:              time.Hour,
+			CountDeadlineExceeded: true,
+		},
+	})
+	fixedNow := time.Unix(600, 0)
+	tr.now = func() time.Time { return fixedNow }
+
+	req1 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp, err := tr.RoundTrip(req1)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %#v", resp)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	req2 := newRPCRequest(t, u1, "eth_blockNumber")
+	resp = mustRoundTrip(t, tr, req2)
+	assertStatus(t, resp, 200)
+
+	assertCalls(t, base, u1, u1)
+}
+
 func TestCooldown_TripsAfterNConsecutiveFailoverFailures_SkipsCooledUpstream(t *testing.T) {
 	u1 := "https://u1.test/rpc"
 	u2 := "https://u2.test/rpc"


### PR DESCRIPTION
Adds `CooldownConfig.CountDeadlineExceeded`, an opt-in setting that records attempted `context.DeadlineExceeded` outcomes as cooldown failures.

The current request still returns immediately and does not fail over when its context deadline is exceeded. `context.Canceled` does not count toward cooldown, and default behavior remains unchanged.

Includes tests for enabled deadline counting, default non-counting behavior, and canceled contexts. Updates the README with the new cooldown option.

Closes #9